### PR TITLE
Adding an 'extend' option which adds 4-directional padding where the pad is the color of the edge pixel

### DIFF
--- a/lib/exporters.js
+++ b/lib/exporters.js
@@ -37,31 +37,44 @@ function getExporter(ext) {
       var img = imageObj.img;
       var xOffset = imageObj.x;
       var yOffset = imageObj.y;
-      var extend = (imageObj.meta && imageObj.meta.extend ? imageObj.meta.extend : 0);
-      var leftEdge = xOffset + extend;
-      var topEdge = yOffset + extend;
-      var rightEdge = xOffset + img.width - extend;
-      var bottomEdge = yOffset + img.height - extend;
+      var extend = (options.extend || 0);
+      var leftEdge = extend;
+      var topEdge = extend;
+      var rightEdge = img.width + extend;
+      var bottomEdge = img.height + extend;
 
       var sourceX;
       var sourceY;
 
-      var x = 0;
-      var maxX = img.width;
-      for (; x < maxX; x += 1) {
-        var y = 0;
-        var maxY = img.height;
-        for (; y < maxY; y += 1) {
+      var maxX = img.width + extend * 2;
+      var maxY = img.height + extend * 2;
+
+      for (var x = 0; x < maxX; x += 1) {
+        for (var y = 0; y < maxY; y += 1) {
           var rgbaIndex = 0;
           var rgbaCount = 4;
 
           if (extend){
-            sourceX = (x < leftEdge ? leftEdge : (
-              x > rightEdge ? rightEdge : x
-            ));
-            sourceY = (y < topEdge ? topEdge : (
-              y > bottomEdge ? bottomEdge : y
-            ));
+            if (x < leftEdge){
+              sourceX = 0;
+
+            } else if (x >= rightEdge){
+              sourceX = img.width - 1;
+
+            } else {
+              sourceX = x - leftEdge;
+
+            }
+            if (y < topEdge){
+              sourceY = 0;
+
+            } else if (y >= bottomEdge){
+              sourceY = img.height - 1;
+
+            } else {
+              sourceY = y - topEdge;
+
+            }
 
           } else {
             sourceX = x;
@@ -74,7 +87,7 @@ function getExporter(ext) {
             var val;
             if (img.shape.length === 4) {
               val = img.get(0, sourceX, sourceY, rgbaIndex);
-            // Otherwise, transfer data directly
+              // Otherwise, transfer data directly
             } else {
               val = img.get(sourceX, sourceY, rgbaIndex);
             }

--- a/lib/exporters.js
+++ b/lib/exporters.js
@@ -37,25 +37,48 @@ function getExporter(ext) {
       var img = imageObj.img;
       var xOffset = imageObj.x;
       var yOffset = imageObj.y;
-      var colIndex = 0;
-      var colCount = img.width; // DEV: Use `width` for padding
-      for (; colIndex < colCount; colIndex += 1) {
-        var rowIndex = 0;
-        var rowCount = img.height; // DEV: Use `height` for padding
-        for (; rowIndex < rowCount; rowIndex += 1) {
+      var extend = (imageObj.meta && imageObj.meta.extend ? imageObj.meta.extend : 0);
+      var leftEdge = xOffset + extend;
+      var topEdge = yOffset + extend;
+      var rightEdge = xOffset + img.width - extend;
+      var bottomEdge = yOffset + img.height - extend;
+
+      var sourceX;
+      var sourceY;
+
+      var x = 0;
+      var maxX = img.width;
+      for (; x < maxX; x += 1) {
+        var y = 0;
+        var maxY = img.height;
+        for (; y < maxY; y += 1) {
           var rgbaIndex = 0;
           var rgbaCount = 4;
+
+          if (extend){
+            sourceX = (x < leftEdge ? leftEdge : (
+              x > rightEdge ? rightEdge : x
+            ));
+            sourceY = (y < topEdge ? topEdge : (
+              y > bottomEdge ? bottomEdge : y
+            ));
+
+          } else {
+            sourceX = x;
+            sourceY = y;
+          }
+
           for (; rgbaIndex < rgbaCount; rgbaIndex += 1) {
             // If we are working with a 4 dimensional array, ignore the first dimension
             // DEV: This is a GIF; [frames, width, height, rgba]
             var val;
             if (img.shape.length === 4) {
-              val = img.get(0, colIndex, rowIndex, rgbaIndex);
+              val = img.get(0, sourceX, sourceY, rgbaIndex);
             // Otherwise, transfer data directly
             } else {
-              val = img.get(colIndex, rowIndex, rgbaIndex);
+              val = img.get(sourceX, sourceY, rgbaIndex);
             }
-            ndarray.set(xOffset + colIndex, yOffset + rowIndex, rgbaIndex, val);
+            ndarray.set(xOffset + x, yOffset + y, rgbaIndex, val);
           }
         }
       }


### PR DESCRIPTION
Basically for my reasons I needed to add an option for `grunt-spritesmith` to extend the edge pixels of graphics in order to prevent graphical artifacts when scaling sprites in `<game engine>` (outside color bleeding into the edges of the sprite). I've had to fork and modify `grunt-spritesmith`, `spritesmith` and `pixelsmith`.

This code change was made strictly and only for me but I figured out this is a pretty useful feature so I'd like to ask you if you want it in the main repo and would you like to discuss how to best incorporate it to avoid potential issues with other modules.
