### PR TITLE
Remove ndarray-fill from dependencies

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -1,7 +1,6 @@
 // Load in dependencies
 var assert = require('assert');
 var ndarray = require('ndarray');
-var ndarrayFill = require('ndarray-fill');
 var savePixels = require('save-pixels');
 
 // Define our canvas constructor
@@ -35,10 +34,11 @@ Canvas.prototype = {
 
     // If we have a custom background, fill it in (otherwise default is transparent black `rgba(0, 0, 0, 0)`)
     var ndarray = this.ndarray;
+    var data = this.data;
     if (options.background) {
-      ndarrayFill(ndarray, function fillBackground (i, j, k) {
-        return options.background[k];
-      });
+      for (var i = 0; i < data.length; ++i) {
+        data[i] = options.background[i % 4];
+      }
     }
 
     // Add each image to the canvas

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "get-pixels": "~3.3.0",
     "mime-types": "~2.1.7",
     "ndarray": "~1.0.15",
-    "ndarray-fill": "~1.0.1",
     "obj-extend": "~0.1.0",
     "save-pixels": "~2.3.0",
     "vinyl-file": "~1.3.0"


### PR DESCRIPTION
Removes dependency to ndarray-fill which is bloated with multiple transitive dependencies like js parser (esprima). It replaces it with simple for loop.
Additionally, all npm audit vulnerabilities in *production* dependencies are now removed.