### PR TITLE
Bump async to 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "npm run precheck && mocha --reporter dot && npm run lint"
   },
   "dependencies": {
-    "async": "~0.9.0",
+    "async": "^3.2.3",
     "concat-stream": "~1.5.1",
     "get-pixels": "~3.3.0",
     "mime-types": "~2.1.7",


### PR DESCRIPTION
This avoids having a dependency with CVE-2021-43138 in projects that use pixelsmith.

I tested that this still works with Node.js 8 (as mentioned by `"node": ">= 8.0.0"` if mocha gets downgraded).